### PR TITLE
Restore the complicated contract test

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,7 @@ Added
 - Support for the ``logs`` field in ``TxReceipt``. (PR_68_)
 - ``ClientSession.eth_get_logs()`` and ``eth_get_filter_logs()``. (PR_68_)
 - Support for a custom block number in gas estimation methods. (PR_70_)
+- ``LocalProvider`` accepts an ``evm_version`` parameter. (PR_78_)
 
 
 Fixed
@@ -71,6 +72,7 @@ Fixed
 .. _PR_75: https://github.com/fjarri-eth/pons/pull/75
 .. _PR_76: https://github.com/fjarri-eth/pons/pull/76
 .. _PR_77: https://github.com/fjarri-eth/pons/pull/77
+.. _PR_78: https://github.com/fjarri-eth/pons/pull/78
 
 
 0.7.0 (09-07-2023)

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 from typing import Any
 
-from alysis import Node, RPCNode
+from alysis import EVMVersion, Node, RPCNode
 from eth_account import Account
 from ethereum_rpc import Amount
 
@@ -27,8 +27,16 @@ class LocalProvider(Provider):
     root: Signer
     """The signer for the pre-created account."""
 
-    def __init__(self, *, root_balance: Amount, chain_id: int = 1):
-        self._local_node = Node(root_balance_wei=root_balance.as_wei(), chain_id=chain_id)
+    def __init__(
+        self,
+        *,
+        root_balance: Amount,
+        chain_id: int = 1,
+        evm_version: EVMVersion = EVMVersion.CANCUN,
+    ):
+        self._local_node = Node(
+            root_balance_wei=root_balance.as_wei(), chain_id=chain_id, evm_version=evm_version
+        )
         self._rpc_node = RPCNode(self._local_node)
         self.root = AccountSigner(Account.from_key(self._local_node.root_private_key))
         self._default_address = self.root.address

--- a/tests/TestContractFunctionality.sol
+++ b/tests/TestContractFunctionality.sol
@@ -68,38 +68,35 @@ contract Test {
 
     struct ByteInner {
         bytes4 inner1;
-        bytes10 inner2;
+        bytes inner2;
     }
 
     struct Foo {
         bytes4 foo1;
         bytes2[2] foo2;
-        bytes6 foo3;
+        bytes foo3;
+        string foo4;
         ByteInner inner;
     }
 
     event Complicated(
         bytes4 indexed x,
-        bytes8 indexed y,
+        bytes indexed y,
         Foo indexed u,
         ByteInner[2] indexed v
     ) anonymous;
 
     function emitComplicated() public {
+        bytes memory bytestring33len1 = "012345678901234567890123456789012";
+        bytes memory bytestring33len2 = "-12345678901234567890123456789012";
+        ByteInner memory inner1 = ByteInner("0123", bytestring33len1);
+        ByteInner memory inner2 = ByteInner("-123", bytestring33len2);
         bytes2 x = "aa";
         bytes2 y = "bb";
-        emit Complicated(
-            "aaaa",
-            "55555555",
-            Foo(
-                "4567", [x, y],
-                "444444",
-                ByteInner("0123", "3333333333")
-            ),
-            [
-                ByteInner("0123", "1111111111"),
-                ByteInner("-123", "2222222222")
-            ]);
+        bytes2[2] memory foo2 = [x, y];
+        Foo memory foo = Foo("4567", foo2, bytestring33len1, "\u1234\u1212", inner1);
+        ByteInner[2] memory inner_arr = [inner1, inner2];
+        emit Complicated("aaaa", bytestring33len2, foo, inner_arr);
     }
 
     error MyError(address sender);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from alysis import EVMVersion
 from ethereum_rpc import Amount
 
 from pons import AccountSigner, Client, LocalProvider
@@ -6,7 +7,7 @@ from pons import AccountSigner, Client, LocalProvider
 
 @pytest.fixture
 def local_provider():
-    return LocalProvider(root_balance=Amount.ether(100))
+    return LocalProvider(root_balance=Amount.ether(100), evm_version=EVMVersion.CANCUN)
 
 
 @pytest.fixture


### PR DESCRIPTION
Now that we can specify the EVM version used in the testerchain, we can restore the complicated test.