### PR TITLE
Add `get_create2_address()`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -206,6 +206,12 @@ Utility classes
    :members:
 
 
+Utility methods
+---------------
+
+.. autofunction:: pons.get_create2_address
+
+
 Compiled and deployed contracts
 -------------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -209,6 +209,8 @@ Utility classes
 Utility methods
 ---------------
 
+.. autofunction:: pons.get_create_address
+
 .. autofunction:: pons.get_create2_address
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,7 @@ Added
 - Support for a custom block number in gas estimation methods. (PR_70_)
 - ``LocalProvider`` accepts an ``evm_version`` parameter. (PR_78_)
 - ``get_create2_address()``. (PR_80_)
+- ``get_create_address()``. (PR_80_)
 
 
 Fixed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,7 @@ Added
 - ``ClientSession.eth_get_logs()`` and ``eth_get_filter_logs()``. (PR_68_)
 - Support for a custom block number in gas estimation methods. (PR_70_)
 - ``LocalProvider`` accepts an ``evm_version`` parameter. (PR_78_)
+- ``get_create2_address()``. (PR_80_)
 
 
 Fixed
@@ -73,6 +74,7 @@ Fixed
 .. _PR_76: https://github.com/fjarri-eth/pons/pull/76
 .. _PR_77: https://github.com/fjarri-eth/pons/pull/77
 .. _PR_78: https://github.com/fjarri-eth/pons/pull/78
+.. _PR_80: https://github.com/fjarri-eth/pons/pull/80
 
 
 0.7.0 (09-07-2023)

--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -49,6 +49,7 @@ from ._http_provider_server import HTTPProviderServer
 from ._local_provider import LocalProvider, SnapshotID
 from ._provider import HTTPProvider, ProtocolError, Provider, Unreachable
 from ._signer import AccountSigner, Signer
+from ._utils import get_create2_address
 
 __all__ = [
     "ABIDecodingError",
@@ -98,4 +99,5 @@ __all__ = [
     "Unreachable",
     "abi",
     "compile_contract_file",
+    "get_create2_address",
 ]

--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -49,7 +49,7 @@ from ._http_provider_server import HTTPProviderServer
 from ._local_provider import LocalProvider, SnapshotID
 from ._provider import HTTPProvider, ProtocolError, Provider, Unreachable
 from ._signer import AccountSigner, Signer
-from ._utils import get_create2_address
+from ._utils import get_create2_address, get_create_address
 
 __all__ = [
     "ABIDecodingError",
@@ -99,5 +99,6 @@ __all__ = [
     "Unreachable",
     "abi",
     "compile_contract_file",
+    "get_create_address",
     "get_create2_address",
 ]

--- a/pons/_utils.py
+++ b/pons/_utils.py
@@ -1,6 +1,51 @@
 from ethereum_rpc import Address, keccak
 
 
+def _rlp_encode(value: int | bytes | list[int | bytes]) -> bytes:
+    """
+    A limited subset of RLP encoding, so that we don't have to carry a whole `rlp` dependency
+    just for contract address calculation.
+    """
+    list_size_limit = 55
+    list_prefix = 0xC0
+    string_size_limit = 55
+    string_prefix = 0x80
+    small_int_limit = 0x7F
+
+    if isinstance(value, list):
+        items = [_rlp_encode(item) for item in value]
+        list_bytes = b"".join(items)
+        assert len(list_bytes) <= list_size_limit  # noqa: S101
+        return (list_prefix + len(list_bytes)).to_bytes(1, byteorder="big") + list_bytes
+
+    if isinstance(value, int):
+        # Note that there is an error in the official docs.
+        # It says "For a single byte whose value is in the [0x00, 0x7f] (decimal [0, 127]) range,
+        # that byte is its own RLP encoding."
+        # But the encoding of `0` is `0x80`, not `0x00`
+        # (that is, the encoding of a 0-length string).
+        if 0 < value <= small_int_limit:
+            return value.to_bytes(1, byteorder="big")
+        value_len = (value.bit_length() + 7) // 8
+        return _rlp_encode(value.to_bytes(value_len, byteorder="big"))
+
+    assert len(value) <= string_size_limit  # noqa: S101
+    return (string_prefix + len(value)).to_bytes(1, byteorder="big") + value
+
+
+def get_create_address(deployer: Address, nonce: int) -> Address:
+    """
+    Returns the deterministic deployed contract address as produced by ``CREATE`` opcode.
+    Here `deployer` is the contract address invoking ``CREATE`` (if initiated in a contract),
+    or the transaction initiator, if a contract is created via an RPC transaction.
+    ``init_code`` is the deployment code (see :py:attr:`~pons.BoundConstructorCall.data_bytes`).
+    """
+    # This will not hit the length limits since the nonce length is 32 bytes,
+    # and the address length is 20 bytes, which, with length specifiers, is 54 bytes in total.
+    contract_address = keccak(_rlp_encode([bytes(deployer), nonce]))[-20:]
+    return Address(contract_address)
+
+
 def get_create2_address(deployer: Address, init_code: bytes, salt: bytes) -> Address:
     """
     Returns the deterministic deployed contract address as produced by ``CREATE2`` opcode.

--- a/pons/_utils.py
+++ b/pons/_utils.py
@@ -1,0 +1,15 @@
+from ethereum_rpc import Address, keccak
+
+
+def get_create2_address(deployer: Address, init_code: bytes, salt: bytes) -> Address:
+    """
+    Returns the deterministic deployed contract address as produced by ``CREATE2`` opcode.
+    Here `deployer` is the contract address invoking ``CREATE2``
+    (**not** the transaction initiator),
+    ``init_code`` is the deployment code (see :py:attr:`~pons.BoundConstructorCall.data_bytes`),
+    and ``salt`` is a length 32 bytestring.
+    """
+    if len(salt) != 32:  # noqa: PLR2004
+        raise ValueError("Salt must be 32 bytes in length")
+    contract_address = keccak(b"\xff" + bytes(deployer) + salt + keccak(init_code))[-20:]
+    return Address(contract_address)

--- a/tests/TestUtils.sol
+++ b/tests/TestUtils.sol
@@ -1,0 +1,45 @@
+pragma solidity >=0.8.0 <0.9.0;
+
+
+contract ToDeploy {
+    uint256 public state;
+
+    constructor(uint256 _state) {
+        state = _state;
+    }
+
+    function getState() public view returns (uint256) {
+        return state;
+    }
+}
+
+
+contract Create2Deployer {
+    event Deployed(
+        address deployedAddress
+    );
+
+    function deploy(bytes memory bytecode, bytes32 _salt) public payable {
+        address addr;
+        bool success = true;
+
+        assembly {
+            addr := create2(
+                callvalue(),
+                add(bytecode, 0x20), // Skip the first 32 bytes, which is the size of `bytecode`
+                mload(bytecode), // Load the size of code contained in the first 32 bytes
+                _salt
+            )
+
+            if iszero(extcodesize(addr)) {
+                success := false
+            }
+        }
+
+        if (!success) {
+            revert("Failed to deploy the contract");
+        }
+
+        emit Deployed(addr);
+    }
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from pons import EVMVersion, compile_contract_file, get_create2_address
+
+
+@pytest.fixture
+def compiled_contracts():
+    path = Path(__file__).resolve().parent / "TestUtils.sol"
+    return compile_contract_file(path, evm_version=EVMVersion.CANCUN)
+
+
+async def test_create2(session, root_signer, compiled_contracts):
+    compiled_deployer = compiled_contracts["Create2Deployer"]
+    compiled_to_deploy = compiled_contracts["ToDeploy"]
+
+    deployer = await session.deploy(root_signer, compiled_deployer.constructor())
+
+    salt = os.urandom(32)
+    to_deploy = compiled_to_deploy.constructor(123)
+    events = await session.transact(
+        root_signer,
+        deployer.method.deploy(to_deploy.data_bytes, salt),
+        return_events=[deployer.event.Deployed],
+    )
+    assert len(events[deployer.event.Deployed]) == 1
+    assert events[deployer.event.Deployed][0] == dict(
+        deployedAddress=get_create2_address(deployer.address, to_deploy.data_bytes, salt)
+    )
+
+    with pytest.raises(ValueError, match="Salt must be 32 bytes in length"):
+        get_create2_address(deployer.address, to_deploy.data_bytes, salt[:-1])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,12 +4,34 @@ from pathlib import Path
 import pytest
 
 from pons import EVMVersion, compile_contract_file, get_create2_address
+from pons._utils import get_create_address
 
 
 @pytest.fixture
 def compiled_contracts():
     path = Path(__file__).resolve().parent / "TestUtils.sol"
     return compile_contract_file(path, evm_version=EVMVersion.CANCUN)
+
+
+async def test_create(session, root_signer, compiled_contracts):
+    compiled_to_deploy = compiled_contracts["ToDeploy"]
+
+    # Try deploying the contract with different nonces
+
+    nonce = await session.eth_get_transaction_count(root_signer.address)
+    assert nonce == 0
+    to_deploy = await session.deploy(root_signer, compiled_to_deploy.constructor(123))
+    assert to_deploy.address == get_create_address(root_signer.address, nonce)
+
+    nonce = await session.eth_get_transaction_count(root_signer.address)
+    assert nonce == 1
+    to_deploy = await session.deploy(root_signer, compiled_to_deploy.constructor(123))
+    assert to_deploy.address == get_create_address(root_signer.address, nonce)
+
+    nonce = await session.eth_get_transaction_count(root_signer.address)
+    assert nonce == 2
+    to_deploy = await session.deploy(root_signer, compiled_to_deploy.constructor(123))
+    assert to_deploy.address == get_create_address(root_signer.address, nonce)
 
 
 async def test_create2(session, root_signer, compiled_contracts):


### PR DESCRIPTION
Supersedes #79

@artemki2077, compared to your original proposal I changed `salt` to be an integer argument - do you think it is sensible? The examples I found online seem to be all using `uint256` as its type, but if in your usage you would have to call `.to_bytes()` every time, we may as well have it as bytes. 